### PR TITLE
Use preview LibGit2Sharp package to fix local test execution

### DIFF
--- a/src/Ignore.Tests/GitRepoFixture.cs
+++ b/src/Ignore.Tests/GitRepoFixture.cs
@@ -53,7 +53,7 @@
 
         public IEnumerable<StatusEntry> GetUntrackedFiles()
         {
-            var repo = new Repository(RepoPath);
+            using var repo = new Repository(RepoPath);
             var status = repo.RetrieveStatus();
             return status.Untracked;
         }

--- a/src/Ignore.Tests/Ignore.Tests.csproj
+++ b/src/Ignore.Tests/Ignore.Tests.csproj
@@ -18,7 +18,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+        <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
For unknown reason, LibGit2Sharp@0.26.2 creates a symbolic link called `_git2_a31060` when initializing a repository. The problem does not occur with latest preview version.

As it's only used in tests, I feel like it's ok to use a prerelease version.  