### PR TITLE
Don't test all rules all the time

### DIFF
--- a/src/Ignore/Ignore.cs
+++ b/src/Ignore/Ignore.cs
@@ -85,14 +85,16 @@
             var ignore = false;
             foreach (var rule in rules)
             {
-                var currentMatch = rule.IsMatch(path);
-                if (currentMatch && !rule.Negate)
+                if (rule.Negate)
+                {
+                    if (ignore && rule.IsMatch(path))
+                    {
+                        ignore = false;
+                    }
+                }
+                else if (!ignore && rule.IsMatch(path))
                 {
                     ignore = true;
-                }
-                else if (currentMatch && ignore && rule.Negate)
-                {
-                    ignore = false;
                 }
             }
 


### PR DESCRIPTION
If a rule is not going to change the ignore state, it's useless to test if it's matching, saving up a lot of time in regex parsing.  