### PR TITLE
Handle literal dots

### DIFF
--- a/src/Ignore.Tests/GitBasedTests.cs
+++ b/src/Ignore.Tests/GitBasedTests.cs
@@ -69,7 +69,21 @@ foo/
             @"""
 .foo/*
 """,
-            new[] { ".foo/bar", ".foo/.foo/bar", ".foo/har" });
+            new[] { ".foo/bar", ".foo/.foo/bar", ".foo/har", "food" });
+
+        [Fact]
+        public void SimpleIgnore_Dotfiles_WithStar2() => GitBasedTest(
+            @"""
+.vs/*
+""",
+            new[] { "foo/.vs/a.txt", ".vs/a.txt", ".vs/bar/a.txt" });
+
+        [Fact]
+        public void SimpleIgnore_Dotfiles_WithStar3() => GitBasedTest(
+            @"""
+*.mm.*
+""",
+            new[] { "file.mm", "commonFile.txt" });
 
         [Fact]
         public void SimpleIgnore_Dotfiles_WithStar2() => GitBasedTest(
@@ -97,14 +111,14 @@ foo/
             @"""
 /*.cs
 """,
-            new[] { "foo.cs", "foo/bar/foo.cs", "foo/bar/bar.csproj" });
+            new[] { "foo.cs", "foo/bar/foo.cs", "foo/bar/bar.csproj", "foo_cs" });
 
         [Fact]
         public void SubdirStartsWithStar() => GitBasedTest(
             @"""
 foo/*.cs
 """,
-            new[] { "foo.cs", "foo/bar/foo.cs", "foo/foo.cs", "foo/bar/bar.csproj" });
+            new[] { "foo.cs", "foo/bar/foo.cs", "foo/foo.cs", "foo/bar/bar.csproj", "foo/foo_cs" });
 
         [Fact]
         public void TrailingStar() => GitBasedTest(

--- a/src/Ignore.Tests/ReplacerTests.cs
+++ b/src/Ignore.Tests/ReplacerTests.cs
@@ -10,6 +10,8 @@ namespace Ignore.Tests
         public static IEnumerable<object[]> Data =>
             new List<object[]>
             {
+                new object[] { ReplacerStash.LiteralDots, @".foo", "\\.foo" },
+                new object[] { ReplacerStash.LiteralDots, @".foo/.bar", "\\.foo/\\.bar" },
                 new object[] { ReplacerStash.TrailingSpaces, @"aaa\ ", "aaa " },
                 new object[] { ReplacerStash.EscapedSpaces, @"a\ b", "a b" },
                 new object[] { ReplacerStash.Metacharacters, @"a $ . | * + ( ) { ^ b", @"a \$ \. \| \* \+ \( \) \{ \^ b" },

--- a/src/Ignore/IgnoreRule.cs
+++ b/src/Ignore/IgnoreRule.cs
@@ -9,6 +9,7 @@ namespace Ignore
 
         private readonly List<Replacer> replacers = new List<Replacer>
         {
+            ReplacerStash.LiteralDots,
             ReplacerStash.TrailingSpaces,
             ReplacerStash.EscapedSpaces,
             ReplacerStash.Dot,

--- a/src/Ignore/ReplacerStash.cs
+++ b/src/Ignore/ReplacerStash.cs
@@ -5,6 +5,11 @@ namespace Ignore
 
     public static class ReplacerStash
     {
+        public static readonly Replacer LiteralDots = new Replacer(
+            name: nameof(LiteralDots),
+            regex: new Regex(@"\.", RegexOptions.Compiled),
+            replacer: match => "\\.");
+
         public static readonly Replacer TrailingSpaces = new Replacer(
             name: nameof(TrailingSpaces),
             regex: new Regex(@"\\?\s+$", RegexOptions.Compiled),


### PR DESCRIPTION
`.` were not transformed so they could math any character.  