### PR TITLE
Fix TFM

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var isIgnored = ignore.IsIgnored("x.user");
 
 ## Developing
 
-Ignore uses `netstandard2.0` for the main library and `netcoreapp3.1` for the unit tests (Xunit).
+Ignore uses `netstandard2.0` for the main library and `net6.0` for the unit tests (Xunit).
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var isIgnored = ignore.IsIgnored("x.user");
 
 ## Developing
 
-Ignore uses `netstandard2.1` for the main library and `netcoreapp3.1` for the unit tests (Xunit).
+Ignore uses `netstandard2.0` for the main library and `netcoreapp3.1` for the unit tests (Xunit).
 
 ### Build
 


### PR DESCRIPTION
The library hasn't targeted `netstandard2.0` since #14.
