### PR TITLE
Add net8.0 and use Regex source generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
       - name: Build and test

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -2,7 +2,6 @@ name: Ignore NuGet package
 
 on:
   workflow_dispatch:
-    branches: [ main ]
   push:
     branches: [ main ]
 

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
       env:

--- a/.github/workflows/nuget-package.yml
+++ b/.github/workflows/nuget-package.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,6 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" Condition="'$(StyleCopEnabled)'=='true'" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" Condition="'$(StyleCopEnabled)'=='true'" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>Latest</LangVersion>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/ignore.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" Condition="'$(StyleCopEnabled)'=='true'" />
   </ItemGroup>
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN dotnet restore
 
 RUN dotnet build --configuration Release --no-restore
 
-ENTRYPOINT ["dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "--", "-r", "/coverage"]
+ENTRYPOINT ["dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "--results-directory", "/coverage"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ COPY . /app/
 
 WORKDIR /app
 
-ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 RUN dotnet restore
 
-RUN dotnet build --configuration Release --no-restore 
+RUN dotnet build --configuration Release --no-restore
 
-ENTRYPOINT exec dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" -r /coverage
+ENTRYPOINT ["exec", "dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "-r", "/coverage"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 6.0 -Runtime dotnet -InstallDir /usr/share/dotnet
+
 COPY . /app/
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 
 COPY . /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN dotnet restore
 
 RUN dotnet build --configuration Release --no-restore
 
-ENTRYPOINT ["exec", "dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "--", "-r", "/coverage"]
+ENTRYPOINT ["dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "--", "-r", "/coverage"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN dotnet restore
 
 RUN dotnet build --configuration Release --no-restore
 
-ENTRYPOINT ["exec", "dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "-r", "/coverage"]
+ENTRYPOINT ["exec", "dotnet", "test", "--configuration", "Release", "--no-build", "--verbosity", "normal", "--collect:\"XPlat Code Coverage\"", "--", "-r", "/coverage"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ignore
+
 ![Build](https://github.com/goelhardik/ignore/workflows/Build/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/goelhardik/ignore/branch/main/graph/badge.svg?token=5YE7LBW8K0)](https://codecov.io/gh/goelhardik/ignore)
 [![NuGet](https://img.shields.io/nuget/v/Ignore)](https://www.nuget.org/packages/Ignore)
@@ -11,7 +12,7 @@ The library is tested against real `git status` outputs. The tests use `LibGit2S
 
 Ignore can be installed from NuGet.
 
-```
+```PowerShell
 Install-Package Ignore
 ```
 
@@ -41,13 +42,13 @@ var isIgnored = ignore.IsIgnored("x.user");
 
 ## Developing
 
-Ignore uses `netstandard2.0` for the main library and `net6.0` for the unit tests (Xunit).
+Ignore targets `netstandard2.0` and `net8.0` for the main library and uses `net6.0` and `net8.0` for the unit tests (Xunit).
 
 ### Build
 
 From the root directory
 
-```
+```console
 dotnet build
 ```
 
@@ -55,6 +56,6 @@ dotnet build
 
 From the root directory
 
-```
+```console
 dotnet test
 ```

--- a/src/Ignore.Tests/Ignore.Tests.csproj
+++ b/src/Ignore.Tests/Ignore.Tests.csproj
@@ -7,18 +7,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="System.IO.Abstractions" Version="12.2.27" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="1.3.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
+        <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ignore.Tests/Ignore.Tests.csproj
+++ b/src/Ignore.Tests/Ignore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Ignore/Ignore.csproj
+++ b/src/Ignore/Ignore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Ignore/ReplacerStash.cs
+++ b/src/Ignore/ReplacerStash.cs
@@ -3,39 +3,43 @@ namespace Ignore
     using System;
     using System.Text.RegularExpressions;
 
-    public static class ReplacerStash
+    public static partial class ReplacerStash
     {
-        public static readonly Replacer TrailingSpaces = new Replacer(
+        public static readonly Replacer TrailingSpaces = new(
             name: nameof(TrailingSpaces),
-            regex: new Regex(@"\\?\s+$", RegexOptions.Compiled),
-            replacer: match => match.Value.IndexOf("\\", StringComparison.Ordinal) == 0 ? " " : string.Empty);
+            regex: ReplaceExpressions.TrailingSpaces(),
+#if NET8_0_OR_GREATER
+            replacer: match => match.Value.StartsWith('\\') ? " " : string.Empty);
+#else
+            replacer: match => match.Value.StartsWith("\\", StringComparison.Ordinal) ? " " : string.Empty);
+#endif
 
-        public static readonly Replacer EscapedSpaces = new Replacer(
+        public static readonly Replacer EscapedSpaces = new(
             name: nameof(EscapedSpaces),
-            regex: new Regex(@"\\\s", RegexOptions.Compiled),
+            regex: ReplaceExpressions.EscapedSpaces(),
             replacer: match => " ");
 
-        public static readonly Replacer LiteralPlus = new Replacer(
+        public static readonly Replacer LiteralPlus = new(
             name: nameof(LiteralPlus),
-            regex: new Regex(@"\+", RegexOptions.Compiled),
+            regex: ReplaceExpressions.LiteralPlus(),
             replacer: match => @"\+");
 
         // a ? matches any character other than a /
-        public static readonly Replacer QuestionMark = new Replacer(
+        public static readonly Replacer QuestionMark = new(
             name: nameof(QuestionMark),
-            regex: new Regex(@"(?!\\)\?", RegexOptions.Compiled),
+            regex: ReplaceExpressions.QuestionMark(),
             replacer: match => "[^/]");
 
         // a leading / matches the beginning of the path
         // eg. /fake.c only matches fake.c, not src/fake.c
-        public static readonly Replacer LeadingSlash = new Replacer(
+        public static readonly Replacer LeadingSlash = new(
             name: nameof(LeadingSlash),
-            regex: new Regex(@"^\/", RegexOptions.Compiled),
+            regex: ReplaceExpressions.LeadingSlash(),
             replacer: match => "^");
 
-        public static readonly Replacer MetacharacterSlashAfterLeadingSlash = new Replacer(
+        public static readonly Replacer MetacharacterSlashAfterLeadingSlash = new(
             name: nameof(MetacharacterSlashAfterLeadingSlash),
-            regex: new Regex(@"\/", RegexOptions.Compiled),
+            regex: ReplaceExpressions.MetacharacterSlashAfterLeadingSlash(),
             replacer: match => "\\/");
 
         /// <summary>
@@ -44,9 +48,9 @@ namespace Ignore
         /// For example, "**/foo" matches file or directory "foo" anywhere, the same as pattern "foo".
         /// "**/foo/bar" matches file or directory "bar" anywhere that is directly under directory "foo".
         /// </summary>
-        public static readonly Replacer LeadingDoubleStar = new Replacer(
+        public static readonly Replacer LeadingDoubleStar = new(
             name: nameof(LeadingDoubleStar),
-            regex: new Regex(@"^(\*\*/|\*\*)", RegexOptions.Compiled),
+            regex: ReplaceExpressions.LeadingDoubleStar(),
             replacer: match => @".*");
 
         /// <summary>
@@ -54,9 +58,9 @@ namespace Ignore
         /// A slash followed by two consecutive asterisks then a slash matches zero or more directories.
         /// For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
         /// </summary>
-        public static readonly Replacer MiddleDoubleStar = new Replacer(
+        public static readonly Replacer MiddleDoubleStar = new(
             name: nameof(MiddleDoubleStar),
-            regex: new Regex(@"(?<=/)\*\*/", RegexOptions.Compiled),
+            regex: ReplaceExpressions.MiddleDoubleStar(),
             replacer: match => @"(.*/)?");
 
         /// <summary>
@@ -65,18 +69,18 @@ namespace Ignore
         /// "abc/**" matches all files inside directory "abc",
         /// relative to the location of the .gitignore file, with infinite depth.
         /// </summary>
-        public static readonly Replacer TrailingDoubleStar = new Replacer(
+        public static readonly Replacer TrailingDoubleStar = new(
             name: nameof(TrailingDoubleStar),
-            regex: new Regex(@"\*\*$", RegexOptions.Compiled),
+            regex: ReplaceExpressions.TrailingDoubleStar(),
             replacer: match => @".*$");
 
         /// <summary>
         /// Undocumented cases like foo/**.ps
         /// Treat ** as match any character other than /.
         /// </summary>
-        public static readonly Replacer OtherDoubleStar = new Replacer(
+        public static readonly Replacer OtherDoubleStar = new(
             name: nameof(TrailingDoubleStar),
-            regex: new Regex(@"\*\*", RegexOptions.Compiled),
+            regex: ReplaceExpressions.OtherDoubleStar(),
             replacer: match => @"[^/]*");
 
         /// <summary>
@@ -86,9 +90,9 @@ namespace Ignore
         /// The leading slash should be gone after using <see cref="LeadingSlash"/>.
         /// So put a ^ in the beginning of the match.
         /// </summary>
-        public static readonly Replacer MiddleSlash = new Replacer(
+        public static readonly Replacer MiddleSlash = new(
             name: nameof(MiddleSlash),
-            regex: new Regex(@"^([^/\^]+/[^/]+)"),
+            regex: ReplaceExpressions.MiddleSlash(),
             replacer: match => $"^{match.Groups[1]}");
 
         /// <summary>
@@ -98,9 +102,9 @@ namespace Ignore
         ///
         /// This regex handles the paths with trailing slash present.
         /// </summary>
-        public static readonly Replacer TrailingSlash = new Replacer(
+        public static readonly Replacer TrailingSlash = new(
             name: nameof(TrailingSlash),
-            regex: new Regex(@"^([^/]+)/$"),
+            regex: ReplaceExpressions.TrailingSlash(),
             replacer: match => $@"(/|^){match.Groups[1]}/");
 
         /// <summary>
@@ -110,9 +114,9 @@ namespace Ignore
         ///
         /// This pattern handles the paths with no trailing slash.
         /// </summary>
-        public static readonly Replacer NoTrailingSlash = new Replacer(
+        public static readonly Replacer NoTrailingSlash = new(
             name: nameof(NoTrailingSlash),
-            regex: new Regex(@"([^/$]+)$"),
+            regex: ReplaceExpressions.NoTrailingSlash(),
             replacer: match => $@"{match.Groups[1]}(/.*)?$");
 
         /// <summary>
@@ -122,29 +126,158 @@ namespace Ignore
         /// Replaces single * with anything other than a /.
         /// Unless the star is in the beginning of the pattern.
         /// </summary>
-        public static readonly Replacer NonLeadingSingleStar = new Replacer(
+        public static readonly Replacer NonLeadingSingleStar = new(
             name: nameof(NonLeadingSingleStar),
-            regex: new Regex(@"(?<!^)(?<!\*)\*(?!\*)"),
+            regex: ReplaceExpressions.NonLeadingSingleStar(),
             replacer: match => @"[^/]*");
 
-        public static readonly Replacer LeadingSingleStar = new Replacer(
+        public static readonly Replacer LeadingSingleStar = new(
             name: nameof(LeadingSingleStar),
-            regex: new Regex(@"^(?<!\*)\*(?!\*)"),
+            regex: ReplaceExpressions.LeadingSingleStar(),
             replacer: match => @".*");
 
-        public static readonly Replacer Ending = new Replacer(
+        public static readonly Replacer Ending = new(
             name: nameof(Ending),
-            regex: new Regex(@"([^/$]+)$"),
+            regex: ReplaceExpressions.Ending(),
             replacer: match => $"{match.Groups[1]}$");
 
-        public static readonly Replacer LiteralDot = new Replacer(
+        public static readonly Replacer LiteralDot = new(
             name: nameof(LiteralDot),
-            regex: new Regex(@"\."),
+            regex: ReplaceExpressions.LiteralDot(),
             replacer: match => @"\.");
 
-        public static readonly Replacer NoSlash = new Replacer(
+        public static readonly Replacer NoSlash = new(
             name: nameof(NoSlash),
-            regex: new Regex(@"(^[^/]*$)"),
+            regex: ReplaceExpressions.NoSlash(),
             replacer: match => $"(^|/){match.Groups[1]}");
+
+        private static partial class ReplaceExpressions
+        {
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\\?\s+$")]
+            public static partial Regex TrailingSpaces();
+#else
+            public static Regex TrailingSpaces() => new Regex(@"\\?\s+$", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\\\s")]
+            public static partial Regex EscapedSpaces();
+#else
+            public static Regex EscapedSpaces() => new Regex(@"\\\s", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\+")]
+            public static partial Regex LiteralPlus();
+#else
+            public static Regex LiteralPlus() => new Regex(@"\+", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"(?!\\)\?")]
+            public static partial Regex QuestionMark();
+#else
+            public static Regex QuestionMark() => new Regex(@"(?!\\)\?", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"^\/")]
+            public static partial Regex LeadingSlash();
+#else
+            public static Regex LeadingSlash() => new Regex(@"^\/", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\/")]
+            public static partial Regex MetacharacterSlashAfterLeadingSlash();
+#else
+            public static Regex MetacharacterSlashAfterLeadingSlash() => new Regex(@"\/", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"^(\*\*/|\*\*)")]
+            public static partial Regex LeadingDoubleStar();
+#else
+            public static Regex LeadingDoubleStar() => new Regex(@"^(\*\*/|\*\*)", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"(?<=/)\*\*/")]
+            public static partial Regex MiddleDoubleStar();
+#else
+            public static Regex MiddleDoubleStar() => new Regex(@"(?<=/)\*\*/", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\*\*$")]
+            public static partial Regex TrailingDoubleStar();
+#else
+            public static Regex TrailingDoubleStar() => new Regex(@"\*\*$", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\*\*")]
+            public static partial Regex OtherDoubleStar();
+#else
+            public static Regex OtherDoubleStar() => new Regex(@"\*\*", RegexOptions.Compiled);
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"^([^/\^]+/[^/]+)")]
+            public static partial Regex MiddleSlash();
+#else
+            public static Regex MiddleSlash() => new Regex(@"^([^/\^]+/[^/]+)");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"^([^/]+)/$")]
+            public static partial Regex TrailingSlash();
+#else
+            public static Regex TrailingSlash() => new Regex(@"^([^/]+)/$");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"([^/$]+)$")]
+            public static partial Regex NoTrailingSlash();
+#else
+            public static Regex NoTrailingSlash() => new Regex(@"([^/$]+)$");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"(?<!^)(?<!\*)\*(?!\*)")]
+            public static partial Regex NonLeadingSingleStar();
+#else
+            public static Regex NonLeadingSingleStar() => new Regex(@"(?<!^)(?<!\*)\*(?!\*)");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"^(?<!\*)\*(?!\*)")]
+            public static partial Regex LeadingSingleStar();
+#else
+            public static Regex LeadingSingleStar() => new Regex(@"^(?<!\*)\*(?!\*)");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"([^/$]+)$")]
+            public static partial Regex Ending();
+#else
+            public static Regex Ending() => new Regex(@"([^/$]+)$");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"\.")]
+            public static partial Regex LiteralDot();
+#else
+            public static Regex LiteralDot() => new Regex(@"\.");
+#endif
+
+#if NET8_0_OR_GREATER
+            [GeneratedRegex(@"(^[^/]*$)")]
+            public static partial Regex NoSlash();
+#else
+            public static Regex NoSlash() => new Regex(@"(^[^/]*$)");
+#endif
+        }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.1"
+    "version": "0.2"
 }


### PR DESCRIPTION
- Add target for `net8.0` and update to C# 12.
- Use the Regex source generator via `[GeneratedRegex]` when targeting `net8.0`.
- Bump the checkout and setup-dotnet actions to v4 to fix warnings about deprecated Node.js versions.
- Remove invalid key from NuGet publishing workflow.
